### PR TITLE
Feature/upgrade postgresql

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,9 +1,9 @@
-FROM php:7.3.7-cli-alpine3.10
+FROM php:8.3.12-cli-alpine3.20
 
 RUN apk update && apk upgrade \
-    && wget https://phar.phpbu.de/phpbu-6.0.14.phar \
-    && chmod +x phpbu-6.0.14.phar \
-    && mv phpbu-6.0.14.phar /usr/local/bin/phpbu
+    && wget https://phar.phpbu.de/phpbu-6.0.23.phar \
+    && chmod +x phpbu-6.0.23.phar \
+    && mv phpbu-6.0.23.phar /usr/local/bin/phpbu
 
 WORKDIR /data
 

--- a/backup/README.md
+++ b/backup/README.md
@@ -10,6 +10,6 @@ To build and release a new version of the image :
 
 ```
 $ docker login docker.io
-$ docker build --tag suezenv/phpbu:6.0.14 .
-$ docker push suezenv/phpbu:6.0.14
+$ docker build --tag suezenv/phpbu:6.0.23 .
+$ docker push suezenv/phpbu:6.0.23
 ```

--- a/backup/postgresql/Dockerfile
+++ b/backup/postgresql/Dockerfile
@@ -1,5 +1,5 @@
-FROM suezenv/phpbu:6.0.14
+FROM suezenv/phpbu:6.0.23
 
-RUN apk add postgresql-client=11.10-r0
+RUN apk add postgresql16-client=16.3-r0
 
 WORKDIR /data


### PR DESCRIPTION
As part of migration of the “postgresql” server version from 11 to 16 in "gaia-preprod" context, we need to update phpbu-postgresql to keep the compatibility.